### PR TITLE
New route resumes, component ResumeListAll, fixed tests

### DIFF
--- a/app/Http/Controllers/Resume/ResumeController.php
+++ b/app/Http/Controllers/Resume/ResumeController.php
@@ -21,7 +21,10 @@ class ResumeController extends Controller
     {
         $resumes = Resume::all();
 
-        dd($resumes);
+        return Inertia::render('ResumeList/ResumeListAll', [
+            'title' => 'Резюме',
+            'resumes' => $resumes
+        ]);
     }
 
     public function getByUser(Request $request): Response

--- a/database/factories/ResumeFactory.php
+++ b/database/factories/ResumeFactory.php
@@ -30,7 +30,13 @@ class ResumeFactory extends Factory
             'experience' => 'менее года',
             'skills' => ['Economy'],
             'educational_institute' => [],
-            'companies' => []
+            'companies' => [],
+            'salary' => $this->faker->numberBetween(20000, 250000),
+            'employment_type' => 'Удаленая работа',
+            'schedule_type' => 'Полная занятость',
+            'relocation' => 'Возможно',
+            'buisness_travel' => 'Готов',
+            'about_me' => 'Some text  about yourself'
         ];
     }
 }

--- a/resources/js/Pages/ResumeCreate/CreateResume.jsx
+++ b/resources/js/Pages/ResumeCreate/CreateResume.jsx
@@ -1017,8 +1017,8 @@ function CreateResume() {
                                     <option value="Невозможно">
                                         Невозможно
                                     </option>
-                                    <option value="Возможено">
-                                        Возможено
+                                    <option value="Возможно">
+                                        Возможно
                                     </option>
                                     <option value="Желательно">
                                         Желательно

--- a/resources/js/Pages/ResumeList/ResumeListAll.jsx
+++ b/resources/js/Pages/ResumeList/ResumeListAll.jsx
@@ -1,0 +1,34 @@
+import { AppPage } from "@/5Layouts/AppPage/AppPage";
+import { AuthContext } from "@/8Shared/store/AuthContext";
+import { usePage } from "@inertiajs/react";
+import React from "react";
+import s from "./ResumeList.module.css";
+import AppText from "@/8Shared/ui/AppText/AppText";
+
+function ResumeListAll({resumes}){
+
+    const user = usePage().props.auth.user;
+
+    console.log(resumes);
+
+    return(
+        <>
+            <AuthContext.Provider value={{ user }}>
+            <>
+                <AppPage>
+                    <main className={s.mainResumeList}>
+                        <AppText
+                            title={"Резюме"}
+                            size="m"
+                            bold
+                            className={s.titleResumeList}
+                        />
+                    </main>
+                </AppPage>
+            </>
+        </AuthContext.Provider>
+        </>
+    )
+}
+
+export default ResumeListAll;

--- a/tests/Feature/ProfileTest.php
+++ b/tests/Feature/ProfileTest.php
@@ -42,7 +42,7 @@ class ProfileTest extends TestCase
 
         $user->refresh();
 
-        $this->assertSame('Test Subscription', $user->name);
+        $this->assertSame('Test User', $user->name);
         $this->assertSame('test@example.com', $user->email);
         $this->assertSame('89991112233', $user->phone);
         $this->assertSame('Test address', $user->address);

--- a/tests/Feature/ResumeTest.php
+++ b/tests/Feature/ResumeTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use App\Enums\EmploymentType;
 use App\Models\Resume;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -15,7 +16,7 @@ class ResumeTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $response = $this->actingAs($user)->get(route('resume.index'));
+        $response = $this->actingAs($user)->get(route('resume.myresumes'));
 
         $response->assertSessionHasNoErrors();
 
@@ -75,13 +76,19 @@ class ResumeTest extends TestCase
             'citizenship' => 'USA',
             'work_permit' => 'USA',
             'education' => 'Высшее образование',
-            'experience' => 'менее года',
+            'experience' => 'нет опыта',
             'skills' => ['Economy'],
-            'educational_institute' => [['title' => 'Универ', 'faculty' => 'мат', 'specialization' => 'физика', 'graduation_year' => '2000-02-02']]
+            'educational_institute' => [['title' => 'Универ', 'faculty' => 'мат', 'specialization' => 'физика', 'start_year' => '2016-02-02', 'graduation_year' => '2000-02-02']],
+            'salary' => '100000',
+            'employment_type' => 'Удаленая работа',
+            'schedule_type' => 'Полная занятость',
+            'relocation' => 'Возможно',
+            'buisness_travel' => 'Готов',
+            'about_me' => 'Some text  about yourself'
         ]);
 
         $response->assertSessionHasNoErrors();
-        $response->assertRedirect(route('resume.index'));
+        $response->assertRedirect(route('resume.myresumes'));
     }
 
     public function test_resume_can_be_updated(): void
@@ -102,13 +109,19 @@ class ResumeTest extends TestCase
             'citizenship' => 'USA',
             'work_permit' => 'USA',
             'education' => 'Высшее образование',
-            'experience' => 'менее года',
+            'experience' => 'нет опыта',
             'skills' => ['Economy'],
-            'educational_institute' => [['title' => 'Универ', 'faculty' => 'мат', 'specialization' => 'физика', 'graduation_year' => '2000-02-02']]
+            'educational_institute' => [['title' => 'Универ', 'faculty' => 'мат', 'specialization' => 'физика', 'start_year' => '2016-02-02', 'graduation_year' => '2020-02-02']],
+            'salary' => '100000',
+            'employment_type' => 'Удаленая работа',
+            'schedule_type' => 'Полная занятость',
+            'relocation' => 'Возможно',
+            'buisness_travel' => 'Готов',
+            'about_me' => 'Some text  about yourself'
         ]);
 
         $response->assertSessionHasNoErrors();
-        $response->assertRedirect(route('resume.index'));
+        $response->assertRedirect(route('resume.myresumes'));
 
         $resume->refresh();
 


### PR DESCRIPTION
1) Новый маршрут resumes ведет теперь на страницу ResumeListAll
2) Сделал базовый каркас компонента ResumeListAll и прокинул на него данные с бэка
3) Пофиксил падающие тесты resume и profile